### PR TITLE
Fixing installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,9 @@ This requires
 
     $ mkdir tmp
     $ cd tmp
-    $ mkdir src
-    $ mkdir bin
-    $ mkdir pkg
-    $ exoprt GOPATH=`pwd`
-    $ go get github.com/utamaro/tangler
+    $ export GOPATH=`pwd`
+    $ go get -d github.com/utamaro/tangler
+    $ cd src/github.com/utamaro/tangler
     $ go build
     $ ./tangler
 


### PR DESCRIPTION
The original steps didn't work for me (Ubuntu 16.04 LTS, backported go1.8.3).

I had to install as described in this pull request.